### PR TITLE
"Secured" the Admin API and disabled the editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Bob1 will be given the same location as rtsp://example.com/Bob1
 This implimentation should be server agnostic, but only tested on taky.
 #### The RTSP Sidecar MUST be located on the same host as the RTSP server!
 
+Overwrite settings by attaching config files to the /data/ folder, as with normal node-red docker.
+
 Supported env variables:
 ```
     environment:

--- a/settings.js
+++ b/settings.js
@@ -164,7 +164,7 @@ module.exports = {
      * The following property can be used to specify a different root path.
      * If set to false, this is disabled.
      */
-    //httpAdminRoot: '/admin',
+    httpAdminRoot: false,
 
     /** The following property can be used to add a custom middleware function
      * in front of all admin http routes. For example, to set custom http
@@ -316,7 +316,7 @@ module.exports = {
      * is not affected by this option. To disable both the editor and the admin
      * API, use either the httpRoot or httpAdminRoot properties
      */
-    //disableEditor: false,
+    disableEditor: true,
 
     /** Customising the editor
      * See https://nodered.org/docs/user-guide/runtime/configuration#editor-themes


### PR DESCRIPTION
set httpAdminRoot to False, in order to disable the HTTP Admin RestAPI
set disableEditor to true in order to disable the editor (This is a bit redundant as httpAdminRoot: false also disables the editor

Added notice about the settings.js in README.md